### PR TITLE
Improve testing of module 2

### DIFF
--- a/module2.test.js
+++ b/module2.test.js
@@ -32,8 +32,13 @@ describe('Module 2 Answers', function() {
         return 'The price is ' + this.price
       }
     };
+    spyOn(car, 'sayPrice').and.callThrough();
+
     var solution = exercises.question2(car);
+
     expect(solution).toEqual('The price is 3000');
+    expect(car.price).toEqual(3000);
+    expect(car.sayPrice).toHaveBeenCalled();
   });
 
   xit('Q3 - Filtering and mapping array of dogs', function() {
@@ -86,7 +91,7 @@ describe('Module 2 Answers', function() {
 
     var solution = exercises.question6(promise);
 
-    solution.then(function(value) {
+    return solution.then(function (value) {
       expect(value).toEqual('I love CYF!')
     });
   });
@@ -108,8 +113,8 @@ describe('Module 2 Answers', function() {
 
     var solution = exercises.question7();
 
-    solution.then(function(value) {
-      expect(value).toEqual('Olá!')
+    return solution.then(function (value) {
+      expect(value).toEqual('Olá!');
     });
   });
 

--- a/module2.test.js
+++ b/module2.test.js
@@ -32,7 +32,9 @@ describe('Module 2 Answers', function() {
         return 'The price is ' + this.price
       }
     };
-    spyOn(car, 'sayPrice').and.callThrough();
+    // This lets us test whether this method actually got called by the
+    // implementation. We "spy on" it to watch for any interactions.
+    jest.spyOn(car, 'sayPrice');
 
     var solution = exercises.question2(car);
 


### PR DESCRIPTION
Previously Q6 and Q7 didn't _return_ the promise chains, so if the assertion in the callback failed this was reported after the test appeared to have passed. Also Q2 didn't assert on all the requirements in the description.